### PR TITLE
Npm postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 ## How to run it
 
-Make sure you have [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed on your system.
+Make sure you have
+[git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed
+on your system.
 
 Prerequisites for running SPOT as stand-alone website using crossfilter:
 
@@ -23,7 +25,10 @@ Prerequisites for running SPOT as stand-alone website using crossfilter:
     ```bash
     npm install
     ```
-    **Note:** some dependencies may require [node-gyp](https://github.com/nodejs/node-gyp). If you get errors during compilation of this package, you may need to install following packages on Ubuntu system or equivalent packages for your distribution.
+    **Note:** some dependencies may require 
+    [node-gyp](https://github.com/nodejs/node-gyp). If you get errors during 
+    compilation of this package, you may need to install following packages on 
+    Ubuntu system or equivalent packages for your distribution.
     ```bash
     sudo apt-get install -y build-essential python libpq-dev
     ```
@@ -33,17 +38,26 @@ Prerequisites for running SPOT as stand-alone website using crossfilter:
     ```
 5. open http://localhost:9966 in a web browser
 
-Building the website is only tested on Linux, but it should work on any OS (Mac OS X for example) that is supported by node and npm.
+Building the website is only tested on Linux, but it should work on any OS (Mac
+OS X for example) that is supported by node and npm.
 
 Hosting the site can be done by any webserver.
 
-Make sure that **Javascript is enabled** in your web browser. SPOT is fully functional in **Google Chrome** and **Chromium** web browsers and it should work in other web browsers. Otherwise, please [submit an issue](https://github.com/NLeSC/spot/issues).
+Make sure that **Javascript is enabled** in your web browser. SPOT is fully
+functional in **Google Chrome** and **Chromium** web browsers and it should work
+in other web browsers. Otherwise, please [submit an
+issue](https://github.com/NLeSC/spot/issues).
 
 ### SQL Database
 
-Spot can also work with a [PostgreSQL](https://www.postgresql.org) database, but this requires either a local or a remote service to run. Commutication between the client and the database server is achieved by using [web socket](https://github.com/socketio/socket.io).
+Spot can also work with a [PostgreSQL](https://www.postgresql.org) database, but
+this requires either a local or a remote service to run. Commutication between
+the client and the database server is achieved by using [web
+socket](https://github.com/socketio/socket.io).
 
-In order to use SPOT with a PostreSQL server, you need to clone the [spot-server](https://github.com/NLeSC/spot-server) repository and follow the instructions in the README. In general, these are the steps to follow:
+In order to use SPOT with a PostreSQL server, you need to clone the
+[spot-server](https://github.com/NLeSC/spot-server) repository and follow the
+instructions in the README. In general, these are the steps to follow:
 
 1. make sure that PostreSQL service is runnning.
 
@@ -55,12 +69,14 @@ In order to use SPOT with a PostreSQL server, you need to clone the [spot-server
 
 ## Desktop version
 
-Desktop version of SPOT is still under development. Available downloads can be found [here](https://github.com/fdiblen/spot-desktop-app/releases/tag/0.1.0).
+Desktop version of SPOT is still under development. Available downloads can be
+found [here](https://github.com/fdiblen/spot-desktop-app/releases/tag/0.1.0).
 
 
 ## Documentation
 
-The spot documentation can be found [here](http://nlesc.github.io/spot/doc/spot/0.1.0/index.html).
+The spot documentation can be found
+[here](http://nlesc.github.io/spot/doc/spot/0.1.0/index.html).
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spot - extensible facet browser
+# SPOT - extensible facet browser
 [![DOI](https://zenodo.org/badge/56071453.svg)](https://zenodo.org/badge/latestdoi/56071453)
 [![Build Status](https://travis-ci.org/NLeSC/spot.svg?branch=master)](https://travis-ci.org/NLeSC/spot)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/182235fbb0d44bb3aeeda9c67773f4be)](https://www.codacy.com/app/NLeSC/spot?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=NLeSC/spot&amp;utm_campaign=Badge_Grade)
@@ -8,12 +8,9 @@
 
 ## How to run it
 
-Prerequisites:
-Make sure you have the following packages are installed on your system:
+Make sure you have [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed on your system.
 
-   - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-
-As a fully stand-alone website, using crossfilter:
+Prerequisites for running SPOT as stand-alone website using crossfilter:
 
 1. follow the instructions to install **node.js**:
     - [via package manager](https://nodejs.org/en/download/package-manager) (suggested)
@@ -30,15 +27,11 @@ As a fully stand-alone website, using crossfilter:
     ```bash
     sudo apt-get install -y build-essential python libpq-dev
     ```
-4. generate page templates:
-    ```bash
-    npm run templates
-    ```
-5. start the web server
+4. start the web server
     ```bash
     npm start
     ```
-6. open http://localhost:9966 in a web browser
+5. open http://localhost:9966 in a web browser
 
 Building the website is only tested on Linux, but it should work on any OS (Mac OS X for example) that is supported by node and npm.
 

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "coverage": "istanbul cover jasmine ; codacy-coverage < coverage/lcov.info",
     "test": "npm run templates ; npm run check ; npm run coverage",
     "fonts": "cp -r 'node_modules/material-design-icons/iconfont' dist/fonts",
-    "start": "npm run fonts && npm run templates && npm run css-watch & budo -v -P --host 0.0.0.0 --live --dir dist --css app.css src/app.js -- -v"
+    "start": "npm run fonts && npm run templates && npm run css-watch & budo -v -P --host 0.0.0.0 --live --dir dist --css app.css src/app.js -- -v",
+    "postinstall": "npm run templates"
   }
 }


### PR DESCRIPTION
in this PR:

I added ``npm run templates`` as a ``postinstall`` task in ``package.json``, such that it's no longer required for users to bother with doing this step by hand.

I adapted the readme such that it's now just a matter of 
```bash
git clone
npm install
npm start
```
it's simply just the steps that are conventional.

Furthermore, I reflowed the text for the README, such that diff tools can be employed sensibly in the future.
