### PR TITLE
BUGFIX: broken lineplot

### DIFF
--- a/src/widgets/models/linechart.js
+++ b/src/widgets/models/linechart.js
@@ -79,7 +79,12 @@ module.exports = BaseChart.extend({
             }
           }],
           yAxes: [
-            { },
+            {
+              type: 'linear',
+              display: true,
+              position: 'left',
+              id: 'first-scale'
+            },
             {
               type: 'linear',
               display: false,
@@ -89,9 +94,12 @@ module.exports = BaseChart.extend({
             {
               type: 'linear',
               display: false,
-              position: 'left',
+              position: 'right',
               id: 'selection-scale',
-              ticks: { min: 0, max: 1 }
+              ticks: {
+                min: 0,
+                max: 1
+              }
             }
           ]
         },

--- a/src/widgets/views/chartjs.js
+++ b/src/widgets/views/chartjs.js
@@ -207,7 +207,7 @@ function update (view) {
     var j = util.partitionValueToIndex(partitionB, group.b);
 
     // only plot if both values are well defined
-    if (i === +i && j === +j) {
+    if (i >= 0 && j >= 0) {
       // data value
       chartData.datasets[j].data[i] = valueFn(group);
       chartData.datasets[j].error[i] = errorFn(group);

--- a/src/widgets/views/chartjs1d.js
+++ b/src/widgets/views/chartjs1d.js
@@ -92,7 +92,6 @@ function update (view) {
 
   var chartData = view._config.data;
   var datasetCount;
-  var secondYOffset;
 
   // update legends and tooltips
   if (partitionB && partitionB.groups && partitionB.groups.length > 1) {
@@ -161,7 +160,8 @@ function update (view) {
   }
 
   aggregate = filter.aggregates.get(4, 'rank');
-  var secondYFn;
+  var secondYFn = false;
+  var secondYOffset = datasetCount;
   if (aggregate) {
     // double the number of datasets for the second y value
     secondYOffset = datasetCount;
@@ -172,8 +172,6 @@ function update (view) {
       }
       return null;
     };
-  } else {
-    secondYFn = false;
   }
 
   util.resizeChartjsData(chartData, partitionA, partitionB, {
@@ -186,11 +184,13 @@ function update (view) {
     var i = util.partitionValueToIndex(partitionA, group.a);
     var j = util.partitionValueToIndex(partitionB, group.b);
 
-    if (i === +i && j === +j) {
+    if (i >= 0 && j >= 0) {
       chartData.datasets[j].data[i].x = group.a;
       chartData.datasets[j].data[i].y = valueFn(group);
       chartData.datasets[j].error[i].x = errorXFn(group);
       chartData.datasets[j].error[i].y = errorYFn(group);
+      chartData.datasets[j].yAxisID = 'first-scale';
+
       if (secondYFn) {
         chartData.datasets[secondYOffset + j].data[i].x = group.a;
         chartData.datasets[secondYOffset + j].data[i].y = secondYFn(group);
@@ -201,7 +201,7 @@ function update (view) {
     }
   });
 
-  // Add an extra dataset to hightlight selected area
+  // Add an extra dataset to highlight selected area
   var selectionId = datasetCount;
   chartData.datasets[selectionId] = chartData.datasets[selectionId] || {
     data: [ {x: null, y: 1}, {x: null, y: 1} ],

--- a/src/widgets/views/chartjs2d.js
+++ b/src/widgets/views/chartjs2d.js
@@ -237,7 +237,7 @@ function updateBubbles (view) {
     var i = util.partitionValueToIndex(partitionA, group.a);
     var j = util.partitionValueToIndex(partitionB, group.b);
 
-    if (i === +i && j === +j && group.aa !== misval && group.bb !== misval && group.count !== 0) {
+    if (i >= 0 && j >= 0 && group.aa !== misval && group.bb !== misval && group.count !== 0) {
       // initialize if necessary
       chartData.datasets[0].data[d] = chartData.datasets[0].data[d] || {};
       chartData.datasets[0].error[d] = chartData.datasets[0].error[d] || {};

--- a/src/widgets/views/scatter.js
+++ b/src/widgets/views/scatter.js
@@ -169,7 +169,7 @@ function update (view) {
       var j = util.partitionValueToIndex(secondary, group.b);
       var k = util.partitionValueToIndex(tertiary, group.c);
 
-      if (i === +i && j === +j && k === +k) {
+      if (i >= 0 && j >= 0 && k >= 0) {
         visData.add({
           x: primary.groups.models[i].value,
           y: secondary.groups.models[j].value,

--- a/src/widgets/views/util.js
+++ b/src/widgets/views/util.js
@@ -23,7 +23,7 @@ function partitionValueToIndex (partition, value) {
     return group.groupIndex;
   } else {
     // string not in partition
-    return null;
+    return -1;
   }
 }
 
@@ -44,25 +44,32 @@ function resizeChartjsData (chartData, partitionA, partitionB, options) {
   var multiDimensional = options.multiDimensional || false;
   var doubleDatasets = options.doubleDatasets || false;
 
+  var totalDatasets = doubleDatasets ? 2 * y : y;
+
   var i;
   var j;
   var cut;
 
-  // labels on the primary axis
-  if (partitionA && partitionA.groups && partitionA.groups.length > 0) {
-    cut = chartData.labels.length - x;
+  // match the number of labels needed
+  cut = chartData.labels.length - x;
+  if (cut > 0) {
     chartData.labels.splice(0, cut);
-    for (i = 0; i < x; i++) {
-      chartData.labels[i] = partitionA.groups.models[i].label;
-    }
   }
 
-  var totalDatasets = doubleDatasets ? 2 * y : y;
+  // labels on the primary axis
+  for (i = 0; i < x; i++) {
+    chartData.labels[i] = partitionA.groups.models[i].label;
+  }
 
   // match the number of datasets needed
   cut = chartData.datasets.length - totalDatasets;
   if (cut > 0) {
-    chartData.datasets.splice(0, cut);
+    // BUGFIX: weird behavious for linechart selections and plots
+    // when we remove datasets from the front, everything shifts one place to the 'left',
+    // which will cause issues for linecharts where we use an extra dataset at the back for selections.
+    //
+    // Solution: remove from the back
+    chartData.datasets.splice(chartData.datasets.length, cut);
   }
 
   for (j = 0; j < totalDatasets; j++) {


### PR DESCRIPTION
Weird behaviour for linechart selections and plots due to how we updated plots in views/util.js
We removed datasets from the front, everything shifts one place to the 'left', including the dummy dataset at the back for selections.
This caused animations and autoscaling to go crazy.

Solution: remove from the back