### PR TITLE
added a .zenodo.json file to control metadata on Zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,52 @@
+{
+    "description": "SPOT is an interactive visualization tool for multi-dimensional data. It allows quick analysis of complex datasets and easy identification of correlations between variables.",
+    "license": "Apache-2.0",
+    "title": "SPOT",
+    "upload_type": "software",
+    "creators": [{
+            "affiliation": "Netherlands eScience Center",
+            "name": "Attema, Jisk"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Diblen, Faruk"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Spaaks, Jurriaan H."
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Hage, Willem"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Boogaardt, Laurens"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Verhoeven, Stefan"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Kuppevelt, Dafne"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Werkhoven, Ben"
+        }
+    ],
+    "access_right": "open",
+    "keywords": [
+        "visualization",
+        "crossfilter",
+        "javascript",
+        "cross-platform",
+        "web-app",
+        "exploratory analysis",
+        "brushing",
+        "filtering",
+        "zooming",
+        "plotting"
+    ]
+}


### PR DESCRIPTION
Hey I'm experimenting a bit with controlling the metadata that gets attached to your releases on Zenodo. In this PR, I've added a new file ``.zenodo.json`` which now includes the contributors from https://github.com/NLeSC/SPOT/graphs/contributors as ``creators``. If you also want to include people who make issues and such, there is another field ``contributors`` you can add to the ``.zenodo.json``. Items you include there can have an attribute ``type`` which you can set to ``Other`` or another type from the controlled vocabulary [ContactPerson, DataCollector, DataCurator, DataManager, Editor, Researcher, RightsHolder, Sponsor, Other]. 

Anyway long story short, with this ``.zenodo.json`` file, your release process should be less painful.
-Jurriaan