### PR TITLE
added workaround for a bug

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,7 @@ authors:
     affiliation: "Netherlands eScience Center"
     family-names: Diblen
     given-names: Faruk
-    orcid: "https://orcid.org/0000-0002-0989-929X"
-cff-version: "0.1.0"
+cff-version: "1.0.3"
 commit: aa98969b99151c507d9502a1bf9bd1071e31af8a
 date-released: 2017-10-07
 doi: 10.5281/zenodo.1003346


### PR DESCRIPTION
Hi Faruk,

your ORCID happens to end in X which the current version 1.0.3 of the CITATION.cff spec does not account for (which is a bug BTW; https://github.com/citation-file-format/schema/issues/1). That's why I deleted it for now.

With this PR, at least you'll have a valid CFF file such that we can automatically generate SPOT's metadata on the Research Software Directory (https://www.research-software.nl/software/spot) which should improve its findability by search engines. 

-Jurriaan
